### PR TITLE
Signed wires for screen coordinates in demos.

### DIFF
--- a/hdl/demo/display_demo_dvi.v
+++ b/hdl/demo/display_demo_dvi.v
@@ -52,8 +52,8 @@ module display_demo_dvi(
     );
 
     // Display Timings
-    wire [15:0] sx;                 // horizontal screen position
-    wire [15:0] sy;                 // vertical screen position
+    wire signed [15:0] sx;          // horizontal screen position (signed)
+    wire signed [15:0] sy;          // vertical screen position (signed)
     wire h_sync;                    // horizontal sync
     wire v_sync;                    // vertical sync
     wire de;                        // display enable

--- a/hdl/demo/display_demo_dvi_pmod3.v
+++ b/hdl/demo/display_demo_dvi_pmod3.v
@@ -46,8 +46,8 @@ module display_demo_dvi_pmod3(
     );
 
     // Display Timings
-    wire [15:0] sx;                 // horizontal pixel position
-    wire [15:0] sy;                 // vertical pixel position
+    wire signed [15:0] sx;          // horizontal screen position (signed)
+    wire signed [15:0] sy;          // vertical screen position (signed)
     wire h_sync;                    // horizontal sync
     wire v_sync;                    // vertical sync
     wire de;                        // display enable

--- a/hdl/demo/display_demo_vga.v
+++ b/hdl/demo/display_demo_vga.v
@@ -44,8 +44,8 @@ module display_demo_vga(
     );
 
     // Display Timings
-    wire [15:0] sx;                 // horizontal pixel position
-    wire [15:0] sy;                 // vertical pixel position
+    wire signed [15:0] sx;          // horizontal screen position (signed)
+    wire signed [15:0] sy;          // vertical screen position (signed)
     wire h_sync;                    // horizontal sync
     wire v_sync;                    // vertical sync
     wire de;                        // display enable

--- a/hdl/demo/test_card_gradient.v
+++ b/hdl/demo/test_card_gradient.v
@@ -17,7 +17,7 @@ module test_card_gradient (
     localparam base_green   = 8'h10;
     localparam base_blue    = 8'h4C;
 
-    assign o_red    = base_red + i_y + i_x;
+    assign o_red    = base_red + i_y + {2'b0, i_x};
     assign o_green  = base_green + i_y;
     assign o_blue   = base_blue + i_y;
 endmodule

--- a/hdl/demo/test_card_simple.v
+++ b/hdl/demo/test_card_simple.v
@@ -6,7 +6,7 @@
 // Learn more at https://projectf.io
 
 module test_card_simple #(H_RES=640) (
-    input wire [15:0] i_x,
+    input wire signed [15:0] i_x,
     output wire [7:0] o_red,
     output wire [7:0] o_green,
     output wire [7:0] o_blue

--- a/hdl/demo/test_card_squares.v
+++ b/hdl/demo/test_card_squares.v
@@ -9,8 +9,8 @@ module test_card_squares #(
     H_RES=640,
     V_RES=480
     ) (
-    input wire [15:0] i_x,
-    input wire [15:0] i_y,
+    input wire signed [15:0] i_x,
+    input wire signed [15:0] i_y,
     output wire [7:0] o_red,
     output wire [7:0] o_green,
     output wire [7:0] o_blue


### PR DESCRIPTION
Use signed wires for screen coordinates in demos.
Fix width of i_x in test_card_gradient expression.